### PR TITLE
add support for setting custom attributes on 'assign-browse'

### DIFF
--- a/src/fusty-flow.js
+++ b/src/fusty-flow.js
@@ -84,7 +84,17 @@
     off: Flow.prototype.off,
     fire: Flow.prototype.fire,
     cancel: Flow.prototype.cancel,
-    assignBrowse: function (domNodes) {
+      /**
+         * Assign a browse action to one or more DOM nodes.
+         * @function
+         * @param {Element|Array.<Element>} domNodes
+         * @param {boolean} isDirectory Not used, here to maintain flow.js interface
+         * @param {boolean} singleFile Not used, here to maintain flow.js interface
+         * @param {Object} attributes set custom attributes:
+         *  http://www.w3.org/TR/html-markup/input.file.html#input.file-attributes
+         *  eg: accept: 'image/*'
+         */
+    assignBrowse: function (domNodes, isDirectory, singleFile, attributes) {
       if (typeof domNodes.length == 'undefined') {
         domNodes = [domNodes];
       }
@@ -119,6 +129,10 @@
 
           domNode.appendChild(input);
         }
+
+        each(attributes, function (value, key) {
+          input.setAttribute(key, value);
+        });
         // When new files are added, simply append them to the overall list
         addEvent(input, 'change', this.inputChangeEvent);
       }, this);


### PR DESCRIPTION
flow-btn.js, part of ng-flow, allows you to set custom attributes on the generated <input> tag via the 'flowAttrs' attribute. Those attributes are sent to assignBrowse, and Flow.js sets those. This code was copied from flow.js to implement that functionality here as well. 