### PR TITLE
Prevent HTML entites encoding in response message

### DIFF
--- a/src/fusty-flow.js
+++ b/src/fusty-flow.js
@@ -295,7 +295,12 @@
       }
       // iframe.contentWindow.document - for IE<7
       var doc = $.iFrame.contentDocument || $.iFrame.contentWindow.document;
-      var innerHtml = doc.body.innerHTML;
+
+      //prevent HTML entites encoding :
+      var txt = document.createElement("textarea");
+      txt.innerHTML = doc.body.innerHTML;
+      var innerHtml = txt.value
+
       if ($.flowObj.opts.matchJSON) {
         innerHtml = /(\{.*\})/.exec(innerHtml)[0];
       }


### PR DESCRIPTION
I wanted to have "&" in my message but had them encoded to &amp;. This trick decodes the HTML entities. Tested under IE9 and Chrome