### PR TITLE
Support initFileFn in Fusty-flow

### DIFF
--- a/src/fusty-flow.js
+++ b/src/fusty-flow.js
@@ -355,6 +355,10 @@
       this.flowObj.upload();
     },
     bootstrap: function () {
+      if (typeof this.flowObj.opts.initFileFn === "function") {
+        this.flowObj.opts.initFileFn(this);
+      }
+
       this.abort(true);
       this.finished = false;
       this.error = false;


### PR DESCRIPTION
We use ng-flow a lot and have set our own custom file bootstrap function initFileFn in options to extend the file object with some method of ours.

I can see from the source code that Fusty's bootstrap function does not simply check for the existence of an initFileFn.

It it purposeful? Or can I just PR to add the same logic from flow.js?

Current

```
    bootstrap: function () {
      this.abort(true);
      this.finished = false;
      this.error = false;
},
```

Desired
```

    bootstrap: function () {
      if (typeof this.flowObj.opts.initFileFn === "function") {
        this.flowObj.opts.initFileFn(this);
      }

      this.abort(true);
      this.finished = false;
      this.error = false;
},
```